### PR TITLE
Fix an issue with Yii throwing a fit about a property not being present on the error handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+/.idea

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -27,6 +27,11 @@ class ErrorHandler extends BaseErrorHandler
      */
     public $handler;
 
+    /**
+     * If this isn't here, Yii gets cranky
+     */
+    public $errorAction;
+
     public function init()
     {
         parent::init();


### PR DESCRIPTION
Yii 2 seems to get very cranky if this property is not present on the error handler class.

![screenshot_2](https://user-images.githubusercontent.com/3803475/52003451-8d8a7f80-2492-11e9-8719-dd65f0130b2f.png)
